### PR TITLE
Add precommit hook flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ python-dotenv==0.20.0
 sqlparse==0.4.2
 discord==1.7.3
 discord.py==1.7.3
+pre-commit==2.17.0
+flake8==4.0.1
+black==22.3.0


### PR DESCRIPTION
I added flake8 linter check and black formatter action to precommit hook.
That means, that from now on, you cant push code without passing those checks (and by the way, you can learn a lot from them :)).
Let me know when it will be convenient for you to push it to main.
Also, you may need to run `pre-commit install` to activate it (its a one time thing).
And dont forget to run `pip install -r requirments.txt`.

Also, I want to create a git hook for post git pull. it will run `pip install -r requirments.txt` automatically. Tell me what you think